### PR TITLE
ci(ext): pin gh-release action to v2.2.2

### DIFF
--- a/.github/workflows/release-ext.yml
+++ b/.github/workflows/release-ext.yml
@@ -69,7 +69,7 @@ jobs:
           echo 'EOF' >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release (draft)
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v2.2.2
         with:
           draft: true
           body: '${{ steps.changelog.outputs.changelog }}'


### PR DESCRIPTION
its new release broke the action